### PR TITLE
Add an Ollama Vectoriser class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "torch>=2.7.1",
     "fastparquet>=2024.11.0",
     "pyarrow>=20.0.0",
+    "ollama>=0.5.1"
 ] 
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/src/classifAI_API/__init__.py
+++ b/src/classifAI_API/__init__.py
@@ -1,5 +1,5 @@
 from .indexers import VectorStore
 from .servers import start_api
-from .vectorisers import GcpVectoriser, HuggingFaceVectoriser
+from .vectorisers import GcpVectoriser, HuggingFaceVectoriser, OllamaVectoriser
 
 __version__ = "0.0.1"

--- a/src/classifAI_API/vectorisers/__init__.py
+++ b/src/classifAI_API/vectorisers/__init__.py
@@ -1,1 +1,1 @@
-from .main import GcpVectoriser, HuggingFaceVectoriser
+from .main import GcpVectoriser, HuggingFaceVectoriser, OllamaVectoriser


### PR DESCRIPTION
# 📌 Pull Request Template

> **Please complete all sections**

## ✨ Summary

Adds an OllamaVectoriser class to allow a locally-running ollama server to generate embeddings

## 📜 Changes Introduced

<!-- List key changes made in this PR. Consider bullet points for readability. -->

- [x] feat(vectorisers): add an Ollama Vectoriser class

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [ ] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [ ] Documentation has been updated if needed

## 🔍 How to Test

install ollama:
`curl -fsSL https://ollama.com/install.sh | sh`

start up the ollama server:
`ollama serve`

in a new terminal, pull down a model:
`ollama pull all-minilm:l6-v2` or `ollama pull nomic-embed-text` (or other)

run the demo notebook, and import and use the OllamaVectoriser object, specifying the same 
`model_name` as the one you pulled down.
