### PR TITLE
538 fix vectorstore field info

### DIFF
--- a/src/classifAI_API/indexers/main.py
+++ b/src/classifAI_API/indexers/main.py
@@ -180,66 +180,55 @@ class VectorStore:
     def search(self, query, ids=None, n_results=10):
         """Perform a search on the vectors using the provided query."""
         # convert the query/queries to vectors using the embedder
-
         query_vectors = self.vectoriser.transform(query)
         document_vectors = self.vectors["embeddings"].to_numpy()
         if not ids:
-            ids = list(range(query_vectors.shape[0]))
+            ids = list(range(len(query)))
 
+        # Compute cosine similarity between quries and each document
         cosine = query_vectors @ document_vectors.T
+
+        # Get the top n_results indices for each query
         idx = np.argpartition(cosine, -n_results, axis=1)[:, -n_results:]
 
         # Sort top k indices by their scores in descending order
-        # For each row, get the scores at the top k indices, then sort them
         idx_sorted = np.zeros_like(idx)
         scores = np.zeros_like(idx, dtype=float)
 
-        # Vectorized approach for sorting the top k indices
         for i in range(idx.shape[0]):
             row_scores = cosine[i, idx[i]]
             sorted_indices = np.argsort(row_scores)[::-1]
             idx_sorted[i] = idx[i, sorted_indices]
             scores[i] = row_scores[sorted_indices]
-            # Convert the output dictionary into a Polars DataFrame
 
-            # Convert the numpy arrays to Polars Series
-            result_df = pl.DataFrame(
-                {
-                    "query_id": np.repeat(ids, n_results),
-                    "query_text": np.repeat(query, n_results),
-                    "result_id": idx_sorted.flatten(),
-                    "rank": np.tile(np.arange(n_results), len(ids)),
-                    "score": scores.flatten(),
-                }
-            )
+        # build polars dataframe for reults where query and ids and broadcasted, and rank is tiled
+        result_df = pl.DataFrame(
+            {
+                "query_id": np.repeat(ids, n_results),
+                "query_text": np.repeat(query, n_results),
+                "rank": np.tile(np.arange(n_results), len(ids)),
+                "score": scores.flatten(),
+            }
+        )
+        
+        #get the vector store results ids, texts and metadata based on sorted idx and merge with result_df
+        ranked_docs = self.vectors[idx_sorted.flatten().tolist()].select(['id', 'text', *self.meta_data])
+        merged_df = result_df.hstack(ranked_docs).rename({"id": "doc_id", "text": "doc_text"})
 
-            vectors_data = self.vectors[result_df["result_id"]]
+        #reorder the df into presentable format
+        reordered_df = merged_df.select(
+            [
+                "query_id",
+                "query_text",
+                "doc_id",
+                "doc_text",
+                "rank",
+                "score",
+                *self.meta_data,
+            ]
+        )
 
-            # combine results data with the appropriate data from self.vectors
-            merged_df = vectors_data.drop("embeddings").hstack(
-                result_df.drop("result_id")
-            )
-
-            merged_df = merged_df.rename(
-                {
-                    "id": "doc_id",
-                    "text": "doc_text",
-                }
-            )
-
-            reordered_df = merged_df.select(
-                [
-                    "query_id",
-                    "query_text",
-                    "doc_id",
-                    "doc_text",
-                    "rank",
-                    "score",
-                    *self.meta_data,
-                ]
-            )
-
-            return reordered_df
+        return reordered_df
 
     @classmethod
     def from_filespace(cls, folder_path, vectoriser):


### PR DESCRIPTION
## ✨ Summary

Single line change that records metadata for VectorStore class/objects during constructor code - obtains the shape of the vectors (the embedding dimension). Previously it was collecting the shape of the polars dataframe storing the vectors. Now it collects the correct embedding dimension from the numpy array object.

## 📜 Changes Introduced

- Bug fix: Single line, self.vector_shape attribute is now assigned the value of the embeddings (from main.py in indexers module)

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [ x] Code is formatted using **Black**
- [ x] Imports are sorted using **isort**
- [x ] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x ] Security checks pass using **Bandit**
- [] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [ ] DocStrings follow Google-style and are added as per Pylint recommendations
- [x ] Documentation has been updated if needed

## 🔍 How to Test

This can be tested by running the ipynb demo on a fresh install of this branch. Getting to the stage of creating a VectorStore object and then calling the properties of the object:

```
print(your_vector_store.num_vectors)
print(your_vector_store.vector_shape)
```

previously this would have returned the same value, now they correctly show different values. Firstly the number of vectors in the dataset, secondly the embedding shape of each vector
