### PR TITLE
Fix for forward and reverse search methods/endpoints

### DIFF
--- a/src/classifai_package/indexers/main.py
+++ b/src/classifai_package/indexers/main.py
@@ -292,10 +292,12 @@ class VectorStore:
             query = [query]
 
         if (ids is not None) and not all(
-            isinstance(ids, list),
-            all(isinstance(id, (str, int)) for id in ids),
-            len(ids) == len(query),
-            len(set(ids)) == len(ids),
+            [
+                isinstance(ids, list),
+                all(isinstance(id, (str, int)) for id in ids),
+                len(ids) == len(query),
+                len(set(ids)) == len(ids),
+            ]
         ):
             raise ValueError(
                 "'ids' argument must be a list of unique ints or strings, matching the length of the query argument."


### PR DESCRIPTION
## ✨ Summary

Tidy up of each endpoint functionality that was broken in a previous commit change. The reverse search method is currently fine, but issue discovered with the forward search, where passing unique ids with queries to the search endpoint caused a type error. It was an issue with how we were passing several conditional checks to an all() function.

## 📜 Changes Introduced

- [ ] Put all conditional checks on query ids inside a list in the indexers.py Vectorstore class search method.

## ✅ Checklist

- [ ] Code passes linting with **Ruff**
- [ ] Security checks pass using **Bandit**
- [ ] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [ ] DocStrings follow Google-style and are added as per Pylint recommendations
- [ ] Documentation has been updated if needed

## 🔍 How to Test

Running through the general_workflow notebook and then starting up a rest api server with a custom script and validating that all the endpoints work would successfully validate that the changes made in this PR are effective.
