### PR TITLE
chore(imports): Use __all__ instead of aliasing in __init__ imports

### DIFF
--- a/src/classifai_package/indexers/__init__.py
+++ b/src/classifai_package/indexers/__init__.py
@@ -1,1 +1,7 @@
-from .main import VectorStore as VectorStore
+"""Indexers package."""
+
+from .main import VectorStore
+
+__all__ = [
+    "VectorStore",
+]

--- a/src/classifai_package/servers/__init__.py
+++ b/src/classifai_package/servers/__init__.py
@@ -1,3 +1,7 @@
 """FastAPI server as a package."""
 
-from .main import start_api as start_api
+from .main import start_api
+
+__all__ = [
+    "start_api",
+]


### PR DESCRIPTION
## ✨ Summary

This simple PR changes the previous import pattern in some `__init__.py` files from a recursive aliasing style to the use of `__all__`. Both styles are mainly about satisfying linter rules, however the use of `__all__` 

This makes the public API clearer and more deliberate, avoids depending on linter conventions, and is understood by tooling (IDEs, type checkers, Sphinx).

It separates “what we import” from “what we export” and makes API changes easier to audit and review.

## 📜 Changes Introduced

Changed the import style in `__init__.py` files from:

```python
from .module import Foo as Foo
```

to:

```python
from .module import Foo

__all__ = [
    "Foo",
]
```

- [x] Feature implementation (feat:) / bug fix (fix:) / refactoring (chore:) / documentation (docs:) / testing (test:)
- [ ] Updates to tests and/or documentation
- [ ] Terraform changes (if applicable)

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code passes linting with **Ruff**
- [x] Security checks pass using **Bandit**
- [x] API and Unit tests are written and pass using **pytest**
- [x] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [x] Documentation has been updated if needed

## 🔍 How to Test

Nothing new to test, however you could attempt to use imports in the following style:

```python
from classifai_package.servers import *

...

start_api(vector_stores: ..., endpoint_names: ...)
```
