### PR TITLE
chore(ci): only run ci check on pushes to main and PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 ---
 name: CI
 
-on: # yamllint disable-line rule:truthy
+on:
   push:
+    branches:
+      - main
   pull_request:
     branches-ignore:
       - 'dependabot/**/**'
@@ -11,55 +13,55 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-    lint-test:
-        if: '! github.event.pull_request.draft'
-        name: Lint and Test
-        runs-on: ubuntu-22.04
-        strategy:
-          matrix:
-            python-version: ["3.12"]
+  lint-test:
+    if: '! github.event.pull_request.draft'
+    name: Lint and Test
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        python-version: ["3.12"]
 
-        steps:
-            - name: PR Conventional Commit Validation
-              if: |
-                github.event_name == 'pull_request' &&
-                (github.event.action == 'opened' ||
-                github.event.action == 'synchronize' ||
-                github.event.action == 'reopened' ||
-                github.event.action == 'edited') &&
-                github.actor != 'dependabot[bot]' &&
-                github.actor != 'dependabot-preview[bot]'
-              uses: ytanikin/pr-conventional-commits@1.4.0
-              with:
-                task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
-                custom_labels: '{"feat": "enhancement", "fix": "bug", "docs": "documentation", "test": "test", "ci": "CI/CD", "refactor": "refactor", "perf": "performance", "chore": "chore", "revert": "revert", "wip": "WIP"}'
-                add_scope_label: 'false'
-            - uses: actions/checkout@v4
-            - name: Install uv
-              uses: astral-sh/setup-uv@v6
+    steps:
+      - name: PR Conventional Commit Validation
+        if: |
+          github.event_name == 'pull_request' &&
+          (github.event.action == 'opened' ||
+          github.event.action == 'synchronize' ||
+          github.event.action == 'reopened' ||
+          github.event.action == 'edited') &&
+          github.actor != 'dependabot[bot]' &&
+          github.actor != 'dependabot-preview[bot]'
+        uses: ytanikin/pr-conventional-commits@1.4.0
+        with:
+          task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
+          custom_labels: '{"feat": "enhancement", "fix": "bug", "docs": "documentation", "test": "test", "ci": "CI/CD", "refactor": "refactor", "perf": "performance", "chore": "chore", "revert": "revert", "wip": "WIP"}'
+          add_scope_label: 'false'
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
 
-            - name: Set up Python
-              uses: actions/setup-python@v5
-              with:
-                python-version: ${{ matrix.python-version }}
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
-            - name: Display Python version
-              run: python -c "import sys; print(sys.version)"
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
 
-            - name: Build uv lock file
-              run: uv lock
+      - name: Build uv lock file
+        run: uv lock
 
-            - name: Install dependencies
-              run: uv sync
+      - name: Install dependencies
+        run: uv sync
 
-            - name: setup gitleaks
-              run: make setup-gitleaks
+      - name: setup gitleaks
+        run: make setup-gitleaks
 
-            - name: run gitleaks
-              run: make run-gitleaks
+      - name: run gitleaks
+        run: make run-gitleaks
 
-            - name: check code formatting & vulnerability detection
-              run: make check-python-nofix
+      - name: check code formatting & vulnerability detection
+        run: make check-python-nofix
 
-            - name: Cleanup residue file
-              run: make clean
+      - name: Cleanup residue file
+        run: make clean


### PR DESCRIPTION
# 📌 Pull Request Template

closes #69 

> **Please complete all sections**

## ✨ Summary

This PR changes the CI check so that it only runs on pushes to `main` and PRs. This is to avoid duplicate runs on PRs and maintains security as `main` is branch protected from direct pushes and any changes to an open PR would be checked again.

## 📜 Changes Introduced

-  CI check so that it only runs on pushes to `main` and PRs.

- [x] Feature implementation (feat:) / bug fix (fix:) / refactoring (chore:) / documentation (docs:) / testing (test:)
- [ ] Updates to tests and/or documentation
- [ ] Terraform changes (if applicable)

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code passes linting with **Ruff**
- [x] Security checks pass using **Bandit**
- [x] API and Unit tests are written and pass using **pytest**
- [x] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [x] Documentation has been updated if needed

## 🔍 How to Test

Confirm that the ci check runs only once for this pr.
