### PR TITLE
Add .env.local to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,7 @@ celerybeat.pid
 
 # Environments
 .env
+.env.local
 .venv
 env/
 venv/


### PR DESCRIPTION
**Summary**

This PR adds `.env.local` to the project’s `.gitignore` so that local environment configuration files are not accidentally committed.

**Rationale**

Developers often use `.env.local` to store machine-specific secrets or configuration overrides.  
Ignoring this file:

- Aligns with the existing behaviour for `.env`
- Reduces the risk of committing secrets or machine-specific settings
- Keeps the repository clean from local-only config files  

Fixes #1.

**Changes**

- Add `.env.local` under the “Environments” section of `.gitignore`.

**Testing**

- No runtime code changes introduced.
- Git status confirmed that `.env.local` is now ignored as expected.
