### PR TITLE
fix(ci): Run CI workflow after switching from draft to ready to review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,14 @@ on:
   pull_request:
     branches-ignore:
       - 'dependabot/**/**'
+    types: [opened, synchronize, reopened, edited, ready_for_review]
 concurrency:
   group: "${{ github.head_ref || github.ref }}-${{ github.workflow }}"
   cancel-in-progress: true
 
 jobs:
   lint-test:
-    if: '! github.event.pull_request.draft'
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     name: Lint and Test
     runs-on: ubuntu-22.04
     strategy:


### PR DESCRIPTION
# 📌 Pull Request Template

> **Please complete all sections**

## ✨ Summary

the CI job doesn't currently trigger when a user opens a draft PR and then switched it to ready for review. This ensures the CI recognises this action and re-runs the job.

## 📜 Changes Introduced

<!-- List key changes made in this PR. Consider bullet points for readability. -->

- [x] Feature implementation (feat:) / bug fix (fix:) / refactoring (chore:) / documentation (docs:) / testing (test:)
- [ ] Updates to tests and/or documentation
- [ ] Terraform changes (if applicable)

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code passes linting with **Ruff**
- [x] Security checks pass using **Bandit**
- [x] API and Unit tests are written and pass using **pytest**
- [x] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [x] Documentation has been updated if needed

## 🔍 How to Test

Confirm that CI works after switching to ready to review.
