### PR TITLE
feat: Alternate way to authenticate to GCP Vectoriser

### DIFF
--- a/src/classifai/vectorisers/gcp.py
+++ b/src/classifai/vectorisers/gcp.py
@@ -18,9 +18,22 @@ logging.getLogger("google.api_core").setLevel(logging.WARNING)
 class GcpVectoriser(VectoriserBase):
     """A class for embedding text using Google Cloud Platform's GenAI API.
 
+    This class provides functionality to embed text using Google's GenAI API.
+    It supports two authentication methods for setting up the client:
+
+    1. Using `project_id` and `location`: This method requires specifying the Google Cloud project ID
+       and the location of the GenAI API. It is suitable for users who have a Google Cloud project
+       and want to authenticate using project-based credentials. It will require local authentication through
+       the Google Cloud SDK.
+
+    2. Using `api_key`: This method requires providing an API key for authentication. It is suitable
+       for users who want to authenticate using an API key without specifying a project ID and location.
+       This approach does not require local authentication through the Google Cloud SDK.
+
     Attributes:
         model_name (str): The name of the embedding model to use.
         vectoriser (genai.Client): The GenAI client instance for embedding text.
+        model_config (genai.types.EmbedContentConfig): Configuration for the embedding task.
     """
 
     def __init__(


### PR DESCRIPTION
## ✨ Summary

These changes allow package users to use the GcpVectoriser class without having to authenticate in command line, by using an API key to authenticate a Cloud client (rather than the traditional approach which would require users to have the FCloud CLI tool installed). 

The code changes ensure that the user passes either `[project_id, location]` or `[api_key]` when instantiated the GcpVectoriser, in line with the requirements of the Vertex AI API from Google


I've ALSO changed the default task type of the the default embedding model to 'CLASSIFICATION' in line with how it was previously However I think 'SEMANTIC_SIMILARITY' is also worth considering and that may be the better general default fit. It was set to 'RETREIVAL_DOCUMENT' but this task type has a very specific technical use case and should not be used as default

## 📜 Changes Introduced

<!-- List key changes made in this PR. Consider bullet points for readability. -->

- [ ] Added api_key 'mode' to the GcpVectoriser class init function
- [ ] Updated code documentation to reflect this
- [ ] Changed task type of the embedding model 

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [ ] Code passes linting with **Ruff**
- [ ] Security checks pass using **Bandit**
- [ ] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [ ] DocStrings follow Google-style and are added as per Pylint recommendations
- [ ] Documentation has been updated if needed
