### PR TITLE
feat: Adding hooks parameter to VectorStore.from_filespace method

### DIFF
--- a/src/classifai/indexers/main.py
+++ b/src/classifai/indexers/main.py
@@ -461,7 +461,7 @@ class VectorStore:
         return result_df
 
     @classmethod
-    def from_filespace(cls, folder_path, vectoriser, hooks):
+    def from_filespace(cls, folder_path, vectoriser, hooks: dict | None = None):
         """Creates a `VectorStore` instance from stored metadata and Parquet files.
         This method reads the metadata and vectors from the specified folder,
         validates the contents, and initializes a `VectorStore` object with the


### PR DESCRIPTION
resolves #114 

## ✨ Summary

These changes add the ability for a user to pass hooks to the class method that loads VectorStores from filespace into memory. This reflects the current way that hooks are injected in the constructor method of the Vectorstore.

A VectorStore could now be loaded from filespace while injecting hook in the following manner:

```python

def remove_questionmarks(vectorstoresearchinput_df):
    vectorstoresearchinput_df["query"] = vectorstoresearchinput_df["query"].str.replace("?", "", regex=False)
    return vectorstoresearchinput_df

vectoriser = GcpVectoriser(project_id=xxxxxx)

vectorstore = VectorStore.from_filespace(
    folder_path="./DEMO/testdata",
    vectoriser=vectoriser,
    hooks={"search_preprocess": remove_questionmarks}
)
```


## 📜 Changes Introduced

<!-- List key changes made in this PR. Consider bullet points for readability. -->

- [ ] Added new hooks parameter and logic to VectorStore from_filespace class method
- [ ] Updated doctoring for the from_filespace class function

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [ ] Code passes linting with **Ruff**
- [ ] Security checks pass using **Bandit**
- [ ] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [ ] DocStrings follow Google-style and are added as per Pylint recommendations
- [ ] Documentation has been updated if needed

## 🔍 How to Test

instantiating a simple vectorstore with the code above would test the functionality
