### PR TITLE
feat(quarto docs): add workflow to trigger for quarto build & deployment

### DIFF
--- a/.github/workflows/publish_quarto_docs.yml
+++ b/.github/workflows/publish_quarto_docs.yml
@@ -1,0 +1,51 @@
+on:
+  workflow_dispatch:
+  push:
+    branches: gh-pages-publish
+
+name: Quarto Publish
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+
+      - name: Build uv lock file
+        run: uv lock
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Build Quarto Docs
+        run: uv run quartodoc build
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+
+      - name: Render and Publish
+        uses: quarto-dev/quarto-actions/publish@v2
+        with:
+          target: gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# 📌 Quarto Build & Deployment to GitHub Pages

## ✨ Summary

This PR introduces a workflow to trigger building & deployment of quarto documentation to GitHub pages on changes to a (new) branch `gh-pages-publish`.

This will allow us to update the online documentation separately from releases.

## 📜 Changes Introduced

- [x] feat(CICD): new workflow for build & deployment of documentation site

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [ ] Code passes linting with **Ruff**
- [ ] Security checks pass using **Bandit**
- [ ] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [ ] DocStrings follow Google-style and are added as per Pylint recommendations
- [ ] Documentation has been updated if needed

## 🔍 How to Test

See the example in the throwaway fork.
