### PR TITLE
fix: VectorStoreReverseSearchOutput property naming

### DIFF
--- a/src/classifai/indexers/dataclasses.py
+++ b/src/classifai/indexers/dataclasses.py
@@ -232,15 +232,15 @@ class VectorStoreReverseSearchOutput(pd.DataFrame):
         return self["id"]
 
     @property
-    def doc_label(self) -> pd.Series:
+    def searched_doc_label(self) -> pd.Series:
         return self["searched_doc_label"]
 
     @property
-    def retrieved_doc_label(self) -> pd.Series:
+    def doc_label(self) -> pd.Series:
         return self["doc_label"]
 
     @property
-    def retrieved_doc_text(self) -> pd.Series:
+    def doc_text(self) -> pd.Series:
         return self["doc_text"]
 
 


### PR DESCRIPTION
## ✨ Summary

These changes make a small fix to the `VectorStoreReverseSearchOutput` dataclass. The properties of the class weren't updated to reflect changes made in #80 where we changed several of the column names in this dataclass. 

## 📜 Changes Introduced


- [ ] Updated property names of VectorStoreReverseSearchOutput class to sync with DF columns names

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [ ] Code passes linting with **Ruff**
- [ ] Security checks pass using **Bandit**
- [ ] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [ ] DocStrings follow Google-style and are added as per Pylint recommendations
- [ ] Documentation has been updated if needed

## 🔍 How to Test

I ran each of the notebooks, including the recently created ai notebook and verified that the fastapi deployment script worked, querying all endpoints. I also make sure I could access the searched_doc_label property (and all others) by calling the attributes directly from within the general_workflow notebook demo.

This can be used to perform similar testing and ensuring system still works as such.

<img width="613" height="294" alt="Screenshot 2026-03-27 at 11 51 46" src="https://github.com/user-attachments/assets/5e5d3e6d-dedc-40b8-ad3d-1a9c5618fd9f" />
