### PR TITLE
docs: readme instructions updated to reference 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,3 +55,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - REST API - FastAPI served with Uvicorn
 - Documentation and Demo - README and Jupyter Notebook minimal demo with fake dataset.
 
+
+<!-- Links to tags -->
+[v1.0.0]: https://github.com/datasciencecampus/classifai/compare/v0.2.1...v1.0.0
+[v0.2.1]: https://github.com/datasciencecampus/classifai/compare/v0.2.0...v0.2.1
+[v0.2.0]: https://github.com/datasciencecampus/classifai/compare/v0.1.0...v0.2.0
+[v0.1.0]: https://github.com/datasciencecampus/classifai/releases/tag/v0.1.0

--- a/DEMO/README.md
+++ b/DEMO/README.md
@@ -98,17 +98,17 @@ Activate it (Windows):
 
 ##### Using pip
 
-`pip install "https://github.com/datasciencecampus/classifai/releases/download/v0.2.1/classifai-0.2.1-py3-none-any.whl"`
+`pip install "https://github.com/datasciencecampus/classifai/releases/download/v1.0.0/classifai-1.0.0-py3-none-any.whl"`
 
 ##### Using uv
 
 one-off:
 
-`uv pip install "https://github.com/datasciencecampus/classifai/releases/download/v0.2.1/classifai-0.2.1-py3-none-any.whl"`
+`uv pip install "https://github.com/datasciencecampus/classifai/releases/download/v1.0.0/classifai-1.0.0-py3-none-any.whl"`
 
 add as project dependency:
 
-`uv add "https://github.com/datasciencecampus/classifai/releases/download/v0.2.1/classifai-0.2.1-py3-none-any.whl"`
+`uv add "https://github.com/datasciencecampus/classifai/releases/download/v1.0.0/classifai-1.0.0-py3-none-any.whl"`
 
 
 #### *2)* Install optional dependencies

--- a/README.md
+++ b/README.md
@@ -78,17 +78,17 @@ The current sets of optional dependencies are `[all, huggingface, ollama, gcp]`.
 
 ##### Pip
 ```bash
-pip install "classifai[<dependency list(s)>] @ https://github.com/datasciencecampus/classifai/releases/download/v<version e.g. 0.2.1>/classifai-<version e.g. 0.2.1>-py3-none-any.whl"
+pip install "classifai[<dependency list(s)>] @ https://github.com/datasciencecampus/classifai/releases/download/v<version e.g. 1.0.0>/classifai-<version e.g. 1.0.0>-py3-none-any.whl"
 ```
 
 ##### Astral UV
 One-off add to environment:
 ```bash
-uv pip install "classifai[<dependency list(s)>] @ https://github.com/datasciencecampus/classifai/releases/download/v<version e.g. 0.2.1>/classifai-<version e.g. 0.2.1>-py3-none-any.whl"
+uv pip install "classifai[<dependency list(s)>] @ https://github.com/datasciencecampus/classifai/releases/download/v<version e.g. 1.0.0>/classifai-<version e.g. 1.0.0>-py3-none-any.whl"
 ```
 Persist as an environment requirement:
 ```bash
-uv add "classifai[<dependency list(s)>] @ https://github.com/datasciencecampus/classifai/releases/download/v<version e.g. 0.2.1>/classifai-<version e.g. 0.2.1>-py3-none-any.whl"
+uv add "classifai[<dependency list(s)>] @ https://github.com/datasciencecampus/classifai/releases/download/v<version e.g. 1.0.0>/classifai-<version e.g. 1.0.0>-py3-none-any.whl"
 ```
 
 ## Example: Indexing and searching a knowledgebase


### PR DESCRIPTION
## ✨ Summary

Recent updates to the package took us to version 1.0.0. These changes clean up any documentation that references how to install the package. Specifically updating mentions of version 0.2.1 to 

## 📜 Changes Introduced

- [ ] docs: Updated demos readme to reference install instructions for 1.0.0
- [ ] docs: updated main readme to use 1.0.0 as example for installs

## ✅ Checklist

- [ ] Code passes linting with **Ruff**
- [ ] Security checks pass using **Bandit**
- [ ] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [ ] DocStrings follow Google-style and are added as per Pylint recommendations
- [ ] Documentation has been updated if needed

## 🔍 How to Test

Try installing version 1.0.0 of the package and executing some of the notebooks or code snippets 
