### PR TITLE
fix: make input dataclass id column unique

### DIFF
--- a/src/classifai/indexers/dataclasses.py
+++ b/src/classifai/indexers/dataclasses.py
@@ -20,7 +20,7 @@ class VectorStoreSearchInput(pd.DataFrame):
 
     _schema: pa.DataFrameSchema = pa.DataFrameSchema(
         {
-            "id": pa.Column(str),
+            "id": pa.Column(str, unique=True),
             "query": pa.Column(str),
         },
         coerce=True,
@@ -146,7 +146,7 @@ class VectorStoreReverseSearchInput(pd.DataFrame):
 
     _schema = pa.DataFrameSchema(
         {
-            "id": pa.Column(str),
+            "id": pa.Column(str, unique=True),
             "doc_label": pa.Column(str),
         },
         coerce=True,
@@ -257,7 +257,7 @@ class VectorStoreEmbedInput(pd.DataFrame):
 
     _schema = pa.DataFrameSchema(
         {
-            "id": pa.Column(str),
+            "id": pa.Column(str, unique=True),
             "text": pa.Column(str),
         },
         coerce=True,

--- a/src/classifai/servers/pydantic_models.py
+++ b/src/classifai/servers/pydantic_models.py
@@ -2,7 +2,7 @@
 """Pydantic Classes to model request and response data for ClassifAI FastAPI RESTful API."""
 
 import pandas as pd
-from pydantic import BaseModel, Extra, Field
+from pydantic import BaseModel, Extra, Field, field_validator
 
 
 class SearchRequestEntry(BaseModel):
@@ -23,6 +23,21 @@ class SearchRequestSet(BaseModel):
     """
 
     entries: list[SearchRequestEntry] = Field(description="array of search queries to be searched in the VectorStore.")
+
+    @field_validator("entries", mode="after")
+    @classmethod
+    def _unique_entry_ids(cls, entries: list[SearchRequestEntry]) -> list[SearchRequestEntry]:
+        ids = [e.id for e in entries]
+        seen: set[str] = set()
+        dupes: list[str] = []
+        for i in ids:
+            if i in seen and i not in dupes:
+                dupes.append(i)
+            seen.add(i)
+
+        if dupes:
+            raise ValueError(f"Duplicate entry ids found: {', '.join(dupes)}. Each entry id must be unique.")
+        return entries
 
 
 class SearchResponseEntry(BaseModel):
@@ -71,6 +86,21 @@ class ReverseSearchRequestSet(BaseModel):
     """
 
     entries: list[ReverseSearchRequestEntry] = Field(description="array of VectorStore row entry labels to look up.")
+
+    @field_validator("entries", mode="after")
+    @classmethod
+    def _unique_entry_ids(cls, entries: list[SearchRequestEntry]) -> list[SearchRequestEntry]:
+        ids = [e.id for e in entries]
+        seen: set[str] = set()
+        dupes: list[str] = []
+        for i in ids:
+            if i in seen and i not in dupes:
+                dupes.append(i)
+            seen.add(i)
+
+        if dupes:
+            raise ValueError(f"Duplicate entry ids found: {', '.join(dupes)}. Each entry id must be unique.")
+        return entries
 
 
 class ReverseSearchResponseEntry(BaseModel):
@@ -124,6 +154,21 @@ class EmbedRequestSet(BaseModel):
     entries: list[EmbedRequestEntry] = Field(
         description="array of text entries to be embedded, with their corresponding text and id"
     )
+
+    @field_validator("entries", mode="after")
+    @classmethod
+    def _unique_entry_ids(cls, entries: list[SearchRequestEntry]) -> list[SearchRequestEntry]:
+        ids = [e.id for e in entries]
+        seen: set[str] = set()
+        dupes: list[str] = []
+        for i in ids:
+            if i in seen and i not in dupes:
+                dupes.append(i)
+            seen.add(i)
+
+        if dupes:
+            raise ValueError(f"Duplicate entry ids found: {', '.join(dupes)}. Each entry id must be unique.")
+        return entries
 
 
 class EmbedResponseEntry(BaseModel):


### PR DESCRIPTION
## ✨ Summary

If the user provides an input dataclass containing non-unique `id` column values to a started rest_api, the response will be malformed. This is because the internal logic for converting result dataframes to pydantic modelled json response relies on these id values being unique. 

These changes add Pandera and Pydantic checks to make sure that the input data classes contain only unique id values.

## 📜 Changes Introduced


- [ ] Updated the Pydantic server models to check for duplicates in id columns
- [ ] Updated the Pandera dataclass models to check for duplicates in id columns

## ✅ Checklist


- [ ] Code passes linting with **Ruff**
- [ ] Security checks pass using **Bandit**
- [ ] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [ ] DocStrings follow Google-style and are added as per Pylint recommendations
- [ ] Documentation has been updated if needed

## 🔍 How to Test
