### PR TITLE
fix: replaces strenum with mixin

### DIFF
--- a/src/classifai/servers/main.py
+++ b/src/classifai/servers/main.py
@@ -11,7 +11,7 @@ restAPI endpoints, in a FastAPI restAPI service started with these functions.
 from __future__ import annotations
 
 import logging
-from enum import StrEnum
+from enum import Enum
 from typing import Annotated, Literal
 
 import uvicorn
@@ -134,7 +134,9 @@ def get_server(vector_stores: list[VectorStore], endpoint_names: list[str]) -> F
     return app
 
 
-class LogLevel(StrEnum):
+class LogLevel(str, Enum):
+    """Valid levels of logs."""
+
     DEBUG = "debug"
     INFO = "info"
     WARNING = "warning"
@@ -142,12 +144,17 @@ class LogLevel(StrEnum):
     CRITICAL = "critical"
 
 
+def is_valid_log_level(value: str) -> bool:
+    """Check if `str` is valid log level."""
+    return value in {e.value for e in LogLevel}
+
+
 def run_server(  # noqa: PLR0913
     vector_stores: list[VectorStore],
     endpoint_names: list[str],
     port: int = 8000,
     host_ip: str = "127.0.0.1",
-    log_level: LogLevel | str = "warning",
+    log_level: str = "warning",
     demo_mode: bool = False,
 ):
     """Create and run a `FastAPI` server with search endpoints.
@@ -172,7 +179,7 @@ def run_server(  # noqa: PLR0913
             context={"port": port},
         )
 
-    if log_level not in LogLevel:
+    if not is_valid_log_level(log_level):
         raise DataValidationError(
             f"Invalid log level '{log_level}'. Must be one of: {list(LogLevel)}", context={"log_level": log_level}
         )

--- a/src/classifai/servers/main.py
+++ b/src/classifai/servers/main.py
@@ -181,7 +181,8 @@ def run_server(  # noqa: PLR0913
 
     if not is_valid_log_level(log_level):
         raise DataValidationError(
-            f"Invalid log level '{log_level}'. Must be one of: {list(LogLevel)}", context={"log_level": log_level}
+            f"Invalid log level '{log_level}'. Must be one of: {[member.value for member in LogLevel]}",
+            context={"log_level": log_level},
         )
 
     app = get_server(vector_stores, endpoint_names)


### PR DESCRIPTION
# 📌 Replace StrEnum  with enum

As strenum isn't supported in python 3.10, we are going to replace with a str and enum mixin, type checkers like this better too

## ✨ Summary

Replaces strenum with enum

## 📜 Changes Introduced

<!-- List key changes made in this PR. Consider bullet points for readability. -->

- [x] Feature implementation (feat:) / bug fix (fix:) / refactoring (chore:) / documentation (docs:) / testing (test:)
- [ ] Updates to tests and/or documentation
- [ ] Terraform changes (if applicable)

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code passes linting with **Ruff**
- [x] Security checks pass using **Bandit**
- [x] API and Unit tests are written and pass using **pytest**
- [x] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [x] Documentation has been updated if needed

## 🔍 How to Test

<!-- Describe how reviewers can verify your changes. Include test commands if applicable. -->
To test input valid strings into `run_server()` in the demo, also try seeing errors with non-valid strings, it should return an error message with allowed strings and your own, if it does work logs should only return on the given level