### PR TITLE
ci(release): remove uv version bump, make input value description explicit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version number (e.g., 0.2.0)'
+        description: 'Version number (e.g., 0.2.0) - no leading v'
         required: true
         type: string
 
@@ -99,15 +99,15 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Bump version with uv
-        run: |
-          uv version ${{ inputs.version }}
+      # - name: Bump version with uv
+      #   run: |
+      #     uv version ${{ inputs.version }}
 
-      - name: Commit version bump
-        run: |
-          git add pyproject.toml
-          git commit --allow-empty -m "Bump version to ${{ inputs.version }}"
-          git push
+      # - name: Commit version bump
+      #   run: |
+      #     git add pyproject.toml
+      #     git commit --allow-empty -m "Bump version to ${{ inputs.version }}"
+      #     git push
 
       - name: Download extracted release notes
         uses: actions/download-artifact@v4


### PR DESCRIPTION
# 📌 Remove uv version bump, make input value description explicit

## ✨ Summary

remove uv version bump
make input value description explicit

## 📜 Changes Introduced

- [x] ci: remove `uv` version bump
- [x] docs: make input for release action more clear

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [ ] Code passes linting with **Ruff**
- [ ] Security checks pass using **Bandit**
- [ ] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [ ] DocStrings follow Google-style and are added as per Pylint recommendations
- [ ] Documentation has been updated if needed

## 🔍 How to Test