### PR TITLE
docs(indexers): update from_filespace docstring to include batch_size bug warning

### DIFF
--- a/src/classifai/indexers/main.py
+++ b/src/classifai/indexers/main.py
@@ -960,13 +960,20 @@ class VectorStore:
         metadata.json without being cross-checked against the actual contents
         of the parquet file.
 
+        > <div style="color:darkred">**v1.0.0 compatibility:** VectorStores built before v1.1.0 do not
+            store `batch_size` in `metadata.json`. Pass `batch_size` explicitly
+            when loading such stores, otherwise an `IndexBuildError` is raised.
+            </div>
+
         Args:
             folder_path (str): Path to the folder containing metadata.json and
                 vectors.parquet. Supports any fsspec-compatible path
                 (local, gs://, etc.).
             batch_size (int | None): Overrides the batch_size stored in
                 metadata. Defaults to None, which uses the value from
-                metadata.json.
+                metadata.json. Must be set explicitly when loading a store
+                built before v1.1.0, as older metadata files do not include
+                this field.
             vectoriser: An object with a callable .transform(texts) method. Its
                 class name must match the vectoriser_class value stored in
                 metadata.json.

--- a/src/classifai/indexers/main.py
+++ b/src/classifai/indexers/main.py
@@ -966,7 +966,7 @@ class VectorStore:
 
         **Fix:** upgrade to v1.1.1+, which resolves this issue.
 
-        **Workaround:** If you are unable to update from v1.1.0 to a later version, this issue may be circumvented by manually editing the `metadata.json` file to include a `batch_size` field (e.g., `"batch_size": 128`). **We do not recommend this approach**, nor do we recommend editing the `metadata.json` file directly.
+        **Workaround:** If you are unable to update from v1.1.0 to a later version, this issue may be circumvented by manually editing the `metadata.json` file to include a `batch_size` field (e.g., `"batch_size": 128`). **We advise against this approach**. Editing `metadata.json` directly is not recommended as a general practice and can lead to issues.
         :::
 
         Args:

--- a/src/classifai/indexers/main.py
+++ b/src/classifai/indexers/main.py
@@ -961,14 +961,13 @@ class VectorStore:
         of the parquet file.
 
         :::{.callout-warning}
-        ## Known issue (v1.1.0)
+        ## Known issue (v1.1.0, patched in v1.1.1)
         Loading a `VectorStore` whose `metadata.json` was produced by v1.0.0 (which did not persist `batch_size`) will raise a `DataValidationError` because `batch_size` is listed as a required metadata key. Passing `batch_size` as an argument does **not** bypass this check.
 
-        **Workaround:** manually add `"batch_size": 128` to the `metadata.json` file before calling `from_filespace()`.
-
         **Fix:** upgrade to v1.1.1+, which resolves this issue.
-        :::
 
+        **Workaround:** If you are unable to update from v1.1.0 to a later version, this issue may be circumvented by manually editing the `metadata.json` file to include a `batch_size` field (e.g., `"batch_size": 128`). **We do not recommend this approach**, nor do we recommend editing the `metadata.json` file directly.
+        :::
         Args:
             folder_path (str): Path to the folder containing metadata.json and
                 vectors.parquet. Supports any fsspec-compatible path

--- a/src/classifai/indexers/main.py
+++ b/src/classifai/indexers/main.py
@@ -968,6 +968,7 @@ class VectorStore:
 
         **Workaround:** If you are unable to update from v1.1.0 to a later version, this issue may be circumvented by manually editing the `metadata.json` file to include a `batch_size` field (e.g., `"batch_size": 128`). **We do not recommend this approach**, nor do we recommend editing the `metadata.json` file directly.
         :::
+
         Args:
             folder_path (str): Path to the folder containing metadata.json and
                 vectors.parquet. Supports any fsspec-compatible path

--- a/src/classifai/indexers/main.py
+++ b/src/classifai/indexers/main.py
@@ -960,10 +960,14 @@ class VectorStore:
         metadata.json without being cross-checked against the actual contents
         of the parquet file.
 
-        > <div style="color:darkred">**v1.0.0 compatibility:** VectorStores built before v1.1.0 do not
-            store `batch_size` in `metadata.json`. Pass `batch_size` explicitly
-            when loading such stores, otherwise an `IndexBuildError` is raised.
-            </div>
+        :::{.callout-warning}
+        ## Known issue (v1.1.0)
+        Loading a `VectorStore` whose `metadata.json` was produced by v1.0.0 (which did not persist `batch_size`) will raise a `DataValidationError` because `batch_size` is listed as a required metadata key. Passing `batch_size` as an argument does **not** bypass this check.
+
+        **Workaround:** manually add `"batch_size": 128` to the `metadata.json` file before calling `from_filespace()`.
+
+        **Fix:** upgrade to v1.1.1+, which resolves this issue.
+        :::
 
         Args:
             folder_path (str): Path to the folder containing metadata.json and
@@ -971,9 +975,7 @@ class VectorStore:
                 (local, gs://, etc.).
             batch_size (int | None): Overrides the batch_size stored in
                 metadata. Defaults to None, which uses the value from
-                metadata.json. Must be set explicitly when loading a store
-                built before v1.1.0, as older metadata files do not include
-                this field.
+                metadata.json.
             vectoriser: An object with a callable .transform(texts) method. Its
                 class name must match the vectoriser_class value stored in
                 metadata.json.


### PR DESCRIPTION
## ✨ Summary

`VectorStore.from_filespace()` fails when loading a vector store whose `metadata.json` has `"batch_size": null` (as produced by v1.0.0, which did not persist `batch_size`). This happens when the `batch_size` argument is `None` which is the default argument.

This PR just adds a warning and information to the docstring so that users can still use the package while we create a patch.


## 📜 Changes Introduced

- [x] Added a warning to the docstring that using the `from_filespace` method on vectorstores will cause a `IndexBuildError` and fail unless a batch_size is specified.

## ✅ Checklist

- [x] Code passes linting with **Ruff**
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [x] Documentation has been updated if needed

## 🔍 How to Test

On V1.1.0 using the `DEMO/general_workflow_demo.ipynb` as a start we can add the following after creating `my_vector_store`:

```python
# 1. Create a VectorStore and manually simulate a v1.0.0 metadata file (or any file missing the batch_size)
my_vector_store = VectorStore(
    file_name="data/testdata.csv",
    data_type="csv",
    vectoriser=vectoriser,
    output_dir="testdata",
    overwrite=True,
)

import json
with open("testdata/metadata.json", "r") as f:
    metadata = json.load(f)

metadata["batch_size"] = None  # simulates v1.0.0 metadata

with open("testdata/metadata.json", "w") as f:
    json.dump(metadata, f, indent=2)

# 2. Attempt to reload - raises IndexBuildError
VectorStore.from_filespace(folder_path="testdata", vectoriser=vectoriser)
```

Confirm this causes an `IndexBuildError`. Then change the `from_filespace` method to:
```
VectorStore.from_filespace(folder_path="testdata", vectoriser=vectoriser, batch_size=128)
```
and confirm it now loads successfully.

Read through the changes to the docstrings and ensure it is clear that this is the reccomended workaround. Also render it using quarto and check the `from_filespace` section is clear and rendered properly.

```
quartodoc build && quarto render && quarto preview
```

