### PR TITLE
fix(indexers): update from_filespace method to patch batch_size bug

### DIFF
--- a/src/classifai/indexers/main.py
+++ b/src/classifai/indexers/main.py
@@ -67,6 +67,8 @@ from .dataclasses import (
     VectorStoreSearchOutput,
 )
 
+_BATCH_SIZE = 128
+
 
 class VectorStore:
     """Models and creates vector databases from CSV text files.
@@ -114,7 +116,7 @@ class VectorStore:
         file_name: str,
         data_type: str,
         vectoriser: VectoriserBase,
-        batch_size: int = 128,
+        batch_size: int = _BATCH_SIZE,
         meta_data: dict | None = None,
         output_dir: str | None = None,
         overwrite: bool = False,
@@ -1062,7 +1064,8 @@ class VectorStore:
                 context={"metadata_path": metadata_in_path, "metadata_type": type(metadata).__name__},
             )
 
-        required_keys = ["vectoriser_class", "vector_shape", "num_vectors", "batch_size", "created_at", "meta_data"]
+        # batch size is not required in metadata for backwards compatibility with v1.0.0
+        required_keys = ["vectoriser_class", "vector_shape", "num_vectors", "created_at", "meta_data"]
         missing = [k for k in required_keys if k not in metadata]
         if missing:
             raise DataValidationError(
@@ -1093,6 +1096,18 @@ class VectorStore:
                     "cause_message": str(e),
                 },
             ) from e
+
+        if metadata.get("batch_size") is None:
+            if batch_size is not None:
+                logging.warning(
+                    "Metadata is outdated (pre v1.1.0) and does not contain a batch_size. Using provided batch_size=%d.",
+                    batch_size,
+                )
+            else:
+                logging.warning(
+                    "Metadata is outdated (pre v1.1.0) and does not contain a batch_size. Defaulting to %d.",
+                    _BATCH_SIZE,
+                )
 
         # ---- Load parquet -> IndexBuildError / DataValidationError
         vectors_in_path = os.path.join(folder_path, "vectors.parquet")
@@ -1145,7 +1160,7 @@ class VectorStore:
             vector_store.file_name = None
             vector_store.data_type = None
             vector_store.vectoriser = vectoriser
-            vector_store.batch_size = batch_size or metadata["batch_size"] or 128
+            vector_store.batch_size = batch_size or metadata.get("batch_size") or _BATCH_SIZE
             vector_store.meta_data = deserialized_column_meta_data
             vector_store.vectors = df
             vector_store.vector_shape = metadata["vector_shape"]

--- a/src/classifai/indexers/main.py
+++ b/src/classifai/indexers/main.py
@@ -1145,7 +1145,7 @@ class VectorStore:
             vector_store.file_name = None
             vector_store.data_type = None
             vector_store.vectoriser = vectoriser
-            vector_store.batch_size = batch_size if batch_size is not None else metadata["batch_size"]
+            vector_store.batch_size = batch_size or metadata["batch_size"] or 128
             vector_store.meta_data = deserialized_column_meta_data
             vector_store.vectors = df
             vector_store.vector_shape = metadata["vector_shape"]


### PR DESCRIPTION
## ✨ Summary

`VectorStore.from_filespace()` fails when loading a vector store whose `metadata.json` has `"batch_size": null` (as produced by v1.0.0, which did not persist `batch_size`). This happens when the `batch_size` argument is `None` which is the default argument.

This PR adds a hardcoded fallback option of `batch_size=128` to avoid the situation where `VectorStore` created before v1.1.0 is loaded in and fails due to not persisting any batch_size.

Although hardcoding a value is often seen as bad practice, in this case for the edge case where batch_size and metadata["batch_size"] are both None, this may be the cleanest solution. This would mean that a default batch_size would need to be updated in 2 places when maintaining instead of 1.

Other possible solutions would be to:
1.  Split the `__init__` method into a `__init__` that just sets up the config for the file and a `build` method. This would be similar to scikitlearn and some other libraries. This would mean we could use the `__init__` method when loading from filespace and take the default batch_size. This is quite clean, but a lot of work for such a small issue and goes against our simple one line setup.
2. Create a constant outside of the class in the main.py file called something like _BATCH_SIZE = 128, then use this in the `__init__` and `from_filespace` methods. This means you only have to update the constant in one place. This doesn't appear very elegant to me though.
3. Removing the option of not specifying `batch_size`  or setting a default at 128 and not reading it from filespace.
4. Raise an error and require explicit `batch_size` for legacy stores if both `batch_size` and metadata["batch_size"] are None, telling the user their store was created with v1.0.0 and they must pass `batch_size` explicitly. 
5. Editing the `from_filespace` method to rewrite the dictionary with a default of 128 if it is None.

From all of these I think the most clean ones are either raising the error and letting the user fix it or rewriting the dictionary to avoid the error in the future.


## 📜 Changes Introduced

- [x] Added a hardcoded batch_size to the from_filespace() method in the indexers.main.py file.

## ✅ Checklist

- [x] Code passes linting with **Ruff**
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [x] Documentation has been updated if needed

## 🔍 How to Test

On V1.1.0 main, using the `DEMO/general_workflow_demo.ipynb` as a start we can add the following after creating `my_vector_store`:

```python
# 1. Create a VectorStore and manually simulate a v1.0.0 metadata file (or any file missing the batch_size)
my_vector_store = VectorStore(
    file_name="data/testdata.csv",
    data_type="csv",
    vectoriser=vectoriser,
    output_dir="testdata",
    overwrite=True,
)

import json
with open("testdata/metadata.json", "r") as f:
    metadata = json.load(f)

metadata["batch_size"] = None  # simulates v1.0.0 metadata

with open("testdata/metadata.json", "w") as f:
    json.dump(metadata, f, indent=2)

# 2. Attempt to reload - raises IndexBuildError
VectorStore.from_filespace(folder_path="testdata", vectoriser=vectoriser)
```

Confirm this causes an `IndexBuildError`. 

Then change to this branch and repeat the code and confirm it now loads successfully. Please try any other edge cases you think may be possible.