### PR TITLE
fix: enforce unique id column values in input dataclasses

### DIFF
--- a/src/classifai/indexers/dataclasses.py
+++ b/src/classifai/indexers/dataclasses.py
@@ -29,7 +29,7 @@ class VectorStoreSearchInput(pd.DataFrame):
 
     _schema: pa.DataFrameSchema = pa.DataFrameSchema(
         {
-            "id": pa.Column(str),
+            "id": pa.Column(str, unique=True),
             "query": pa.Column(str),
         },
         coerce=True,
@@ -223,7 +223,7 @@ class VectorStoreReverseSearchInput(pd.DataFrame):
 
     _schema = pa.DataFrameSchema(
         {
-            "id": pa.Column(str),
+            "id": pa.Column(str, unique=True),
             "doc_label": pa.Column(str),
         },
         coerce=True,
@@ -418,7 +418,7 @@ class VectorStoreEmbedInput(pd.DataFrame):
 
     _schema = pa.DataFrameSchema(
         {
-            "id": pa.Column(str),
+            "id": pa.Column(str, unique=True),
             "text": pa.Column(str),
         },
         coerce=True,

--- a/src/classifai/servers/main.py
+++ b/src/classifai/servers/main.py
@@ -15,6 +15,7 @@ import logging
 from enum import Enum
 from typing import Annotated, Literal
 
+import pandera as pa
 import uvicorn
 from fastapi import APIRouter, FastAPI, HTTPException, Query
 from fastapi.responses import RedirectResponse
@@ -252,11 +253,20 @@ def _create_embedding_endpoint(router: APIRouter | FastAPI, endpoint_name: str, 
         description=f"Endpoint to call the `{endpoint_name}` `VectorStore.embed` method",
     )
     async def embedding_endpoint(data: EmbedRequestSet) -> EmbedResponseBody:
+        # Extract relevant fields from the input JSON data
         input_ids = [x.id for x in data.entries]
         input_texts = [x.text for x in data.entries]
 
-        # Creat the input dataclass object and pass it to the vectorstore to get results.
-        input_data = VectorStoreEmbedInput({"id": input_ids, "text": input_texts})
+        # Creat the input dataclass object, raising an informative error if pandera validation fails.
+        try:
+            input_data = VectorStoreEmbedInput({"id": input_ids, "text": input_texts})
+        except pa.errors.SchemaError as e:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Input data failed content validation: {e}",
+            ) from e
+
+        # pass the data to the vectorstore to get results.
         output_data = vector_store.embed(input_data)
 
         # post processing of the Vectorstore output åobject
@@ -293,15 +303,23 @@ def _create_search_endpoint(router: APIRouter | FastAPI, endpoint_name: str, vec
             ),
         ] = 10,
     ) -> SearchResponseBody:
-        # Creat the input dataclass object and pass it to the vectorstore to get results.
+        # Extract relevant fields from the input JSON data
         input_ids = [x.id for x in data.entries]
         queries = [x.query for x in data.entries]
 
-        # Creat the input dataclass object and pass it to the vectorstore to get results.
-        input_data = VectorStoreSearchInput({"id": input_ids, "query": queries})
+        # Creat the input dataclass object, raising an informative error if pandera validation fails.
+        try:
+            input_data = VectorStoreSearchInput({"id": input_ids, "query": queries})
+        except pa.errors.SchemaError as e:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Input data failed content validation: {e}",
+            ) from e
+
+        # pass the data to the vectorstore to get results.
         output_data = vector_store.search(query=input_data, n_results=n_results)
 
-        # post processing of the Vectorstore output åobject
+        # post processing of the Vectorstore output object
         formatted_result = convert_search_dataframe_to_pydantic_response(
             df=output_data,
             meta_data=vector_store.meta_data,
@@ -342,13 +360,22 @@ def _create_reverse_search_endpoint(router: APIRouter | FastAPI, endpoint_name: 
         if max_n_results != -1 and max_n_results < 1:
             raise HTTPException(422, "max_n_results must be -1 or >= 1")
 
-        # Creat the input dataclass object and pass it to the vectorstore to get results.
+        # Extract relevant fields from the input JSON data
         input_ids = [x.id for x in data.entries]
         queries = [x.doc_label for x in data.entries]
 
-        # Creat the input dataclass object and pass it to the vectorstore to get results.
-        input_data = VectorStoreReverseSearchInput({"id": input_ids, "doc_label": queries})
+        # Creat the input dataclass object, raising an informative error if pandera validation fails.
+        try:
+            input_data = VectorStoreReverseSearchInput({"id": input_ids, "doc_label": queries})
+        except pa.errors.SchemaError as e:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Input data failed content validation: {e}",
+            ) from e
+
+        # pass the data to the vectorstore to get results.
         output_data = vector_store.reverse_search(input_data, max_n_results=max_n_results, partial_match=partial_match)
+
         # post processing of the Vectorstore output object
         formatted_result = convert_reverse_search_dataframe_to_pydantic_response(
             df=output_data,


### PR DESCRIPTION
resolves #167 

## ✨ Summary

These changes modify the Pandera schemas of the input dataclasses to ensure that the user doesn't supply dataclasses with non-unique id column values. Non unique values in this case adversely affect data processing in the package because the codebase relies on `df.groupby('id')` statements which assume that the 'id' column has unique values. 

I've added `unique=True` to each of the input dataclass' pandera schemas `id` colmumn specifications. I've also included a servers module update, to catch and raise Pandera validation errors when JSON body information is converted to dataclass input objects, ensuring users know when a specific Pandera issue arises behind the base Pydantic validation. 

(Below) An example screenshot passing non-unique IDs to a VectorStore `reverse_search()` endpoint
<img width="1448" height="750" alt="Screenshot 2026-09-02 at 11 40 52" src="https://github.com/user-attachments/assets/86b68618-95fd-42b2-b2f0-150df04228c8" />


## 📜 Changes Introduced

- [ ] (fix:) Updates to the indexers.dataclasses.py file to specify id columns must be unique
- [ ] (fix:) try catch statements added to servers.main.py file 

## ✅ Checklist

Code passes all pre-commit checks, including optional Docker secret checker step.

## 🔍 How to Test


Below is a simple startup script, using fake data from the ClassifAI repo, that will run a server which the user can pass JSON requests to each endpoint to see the new changes in actions:



```python
from classifai.vectorisers import HuggingFaceVectoriser
from classifai.indexers import VectorStore
from classifai.servers import run_server
from classifai.indexers.dataclasses import VectorStoreReverseSearchInput, VectorStoreSearchInput, VectorStoreEmbedInput


#start a vectoriser
my_vectoriser = HuggingFaceVectoriser(model_name="sentence-transformers/all-MiniLM-L6-v2")


#build a vector store
my_vector_store = VectorStore(
    file_name="./DEMO/data/fake_soc_dataset.csv",
    data_type="csv",
    vectoriser=my_vectoriser,
    skip_save=True,
)

#run a live server for the vectorstore
run_server([my_vector_store], endpoint_names=["test_vectorstore"], log_level="info", demo_mode=True)

```


The final line of code starts a RESTful API service. It would also be good to call the VectorStore methods programatically in Python instead of over a network. See below some example Python code that could be included in the above script <b>replacing</b> the line which runs the server.

For the search method:
```python
# a good input that always worked
test_input_data_1  = VectorStoreSearchInput(
    {"id": ["1", "2"], "query": ["golden farmer", "golden software engineer"]}
)
print(my_vector_store.search(test_input_data_1, n_results=3))


############################

# duplicate ids would have caused problems before changes
test_input_data_2  = VectorStoreSearchInput(
    {"id": ["1", "1"], "query": ["golden farmer", "golden software engineer"]}
)
print(my_vector_store.search(test_input_data_2, n_results=3))
```


For the reverse_search method:

```python
# good test data that's always worked
test_input_data_3  = VectorStoreReverseSearchInput(
    {"id": ["1", "2"], "doc_label": ["101", "130"]}
)
print(my_vector_store.reverse_search(test_input_data_3, max_n_results=3))


############################

# duplicate ids can cause issues
test_input_data_4  = VectorStoreReverseSearchInput(
    {"id": ["1", "1"], "doc_label": ["101", "130"]}
)
print(my_vector_store.reverse_search(test_input_data_4, max_n_results=3))
```


For the embed method:

```python
# another good example that works normally
test_input_data_5 = VectorStoreEmbedInput(
    {"id": ["1", "2"], "text": ["golden farmer", "golden software engineer"]}
)
print(my_vector_store.embed(test_input_data_5))

############################

# duplicate ids can cause issues
test_input_data_6  = VectorStoreEmbedInput(
    {"id": ["1", "1"], "text": ["golden farmer", "golden software engineer"]}
)
print(my_vector_store.embed(test_input_data_6))


```

The above examples can also be applied to the REST API testing. 
