### PR TITLE
chore: Add kwarg options to GCP Vectoriser transform method

### DIFF
--- a/src/classifai/vectorisers/gcp.py
+++ b/src/classifai/vectorisers/gcp.py
@@ -103,12 +103,13 @@ class GcpVectoriser(VectoriserBase):
                 context={"vectoriser": "gcp", "cause": str(e), "cause_type": type(e).__name__},
             ) from e
 
-    def transform(self, texts: str | list[str]) -> np.ndarray:
+    def transform(self, texts: str | list[str], **kwargs) -> np.ndarray:
         """Transforms input text(s) into embeddings using the GenAI API.
 
         Args:
             texts (str | list[str]): The input text(s) to embed. Can be a
                 single string or a list of strings.
+            **kwargs: Additional parameters to pass to the `embed_content` method.
 
         Returns:
             numpy.ndarray: A 2D array of embeddings, where each row
@@ -119,15 +120,23 @@ class GcpVectoriser(VectoriserBase):
             `VectorisationError`: If the response format from the GenAI API is
                 unexpected.
         """
+        from google import genai  # type: ignore
+
         # If a single string is passed as arg to texts, convert to list
         if isinstance(texts, str):
             texts = [texts]
 
+        # Dynamically create the EmbedContentConfig, preserving the constructor's task_type
+        config = genai.types.EmbedContentConfig(
+            task_type=kwargs.pop(
+                "task_type", self.model_config.task_type
+            ),  # Use the constructor's task_type if not overridden
+            **kwargs,  # Pass any additional configuration options
+        )
+
         # The Vertex AI call to embed content
         try:
-            embeddings = self.vectoriser.models.embed_content(
-                model=self.model_name, contents=texts, config=self.model_config
-            )
+            embeddings = self.vectoriser.models.embed_content(model=self.model_name, contents=texts, config=config)
         except Exception as e:
             raise ExternalServiceError(
                 "GCP embedding request failed.",


### PR DESCRIPTION
## ✨ Summary

These changes rework the implementation of the `GcpVectoriser` class' `transform()` method to accept a kwargs argument that is passed to the `embed_content()` call. This allows the user to dynamically modify individual embedding requests, enabling changes to task type, embedding dimension and more.

Specific alterations to the code include adding a `**kwargs` argument to the `GcpVectoriser` `transform()` method:

```python
    def transform(self, texts: str | list[str], **kwargs) -> np.ndarray:
```

and then introducing code that merges these kwarg items with relevant embed arguments that were passed to the constructor, before passing the content to the `embed_content()` call to GCP:

```python
        # Dynamically create the EmbedContentConfig, preserving the constructor's task_type
        config = genai.types.EmbedContentConfig(
            task_type=kwargs.pop(
                "task_type", self.model_config.task_type
            ),  # Use the constructor's task_type if not overridden
            **kwargs,  # Pass any additional configuration options
        )

        # The Vertex AI call to embed content
        try:
            embeddings = self.vectoriser.models.embed_content(model=self.model_name, contents=texts, config=config)
        except Exception as e:
            ... # the rest of the code
```


## 📜 Changes Introduced

- [ ] (feat:) modified the GcpVectoriser class transform method code.

## ✅ Checklist

Passes all precommit checks on commit and push

## 🔍 How to Test

To test these changes, try passing some different values to the `GcpVectoriser` and its `transform()` method. All code can be executed on this branch's version of the code. I cloned the rep, checkout out this branch and the performed `uv lock`, and `uv sync --extra gcp` to get an executable environment (`uv run yourtestscript.py`).

You also need a valid GCP account/project and need to be authenticated before running the below code, with the correct Vertex AI and Generative AI APIs enabled on you GCP project.


First instantiate a Vectoriser with a specific task type:
```python
from classifai.vectorisers import GcpVectoriser

vectoriser = GcpVectoriser(project_id=<YOUR-PROJECT-ID>, location=<YOUR-LOCATION>, vertexai=True, task_type="SEMANTIC_SIMILARITY")
```

Then you can make some calls to the GcpVectoriser transform method to see the effects of the new code changes. First try getting an embedding of 10 elements:

```python
output1 = vectoriser.transform("This is a test string to be embedded using the GCP vectoriser.", output_dimensionality=10)
print(output1)
```

Then try modifying the task type and observing the different values of the embeddings:
```python
output2= vectoriser.transform("This is a test string to be embedded using the GCP vectoriser.", output_dimensionality=5, task_type="CLASSIFICATION")
print(output2)
```

Finally, try keeping the same shorter dimensionality but return to the original task type and see how the values of the third output are the same as the values in the first output - here it isn't actually be necessary to include the task_type argument explicitly, the instance config already contains `task_type=SEMANTIC_Similarity` - but I've included it anyway for illustration.

```python
output3 = vectoriser.transform("This is a test string to be embedded using the GCP vectoriser.", output_dimensionality=5, task_type="SEMANTIC_SIMILARITY")
print(output3)
```


This gives a short demonstration of how the task type is being overwritten from the constructor to the transform method, and how we can now pass new kwarg arguments like the `output_dimensionality` 




